### PR TITLE
feat: localize main controller

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,13 @@
 
 **Desktop Video Wallpaper** is a lightweight dynamic wallpaper app for macOS. It runs entirely offline — no data is uploaded or synced to the cloud, ensuring your privacy and local control.
 
+### Version 3.1 hot-fix 12 (2025-09-02)
+
+- 为主控制器侧边栏添加本地化支持
+- Add localization support for main controller sidebar
+- 补全缺失的多语言翻译
+- Complete missing translations in resource file
+
 ### Version 3.1 hot-fix 11 (2025-09-02)
 
 - 在主界面调整通用设置时加入重启提示

--- a/Desktop Vdieo/Desktop Vdieo/Localizable.xcstrings
+++ b/Desktop Vdieo/Desktop Vdieo/Localizable.xcstrings
@@ -211,6 +211,18 @@
             "value" : "Choose Video…"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleccionar video o imagen…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisir une vidéo ou une image…"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -232,6 +244,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Clear"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Borrar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Effacer"
           }
         },
         "zh-Hans" : {
@@ -357,7 +381,39 @@
       }
     },
     "Desktop Video" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desktop Video"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desktop Video"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desktop Video"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desktop Video"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desktop Video"
+          }
+        }
+      }
     },
     "DiscardChange" : {
       "extractionState" : "manual",
@@ -468,7 +524,39 @@
       "shouldTranslate" : false
     },
     "General" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "General"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "General"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Général"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一般"
+          }
+        }
+      }
     },
     "GlobalMute" : {
       "extractionState" : "manual",
@@ -841,6 +929,18 @@
             "value" : "Pause"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pausar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pause"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -864,6 +964,18 @@
             "value" : "Play"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reproducir"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lire"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -879,7 +991,39 @@
       }
     },
     "Playback" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Playback"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reproducción"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lecture"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "播放"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "播放"
+          }
+        }
+      }
     },
     "PlaybackAlways" : {
       "extractionState" : "manual",
@@ -1690,7 +1834,39 @@
       }
     },
     "Stretch to fill" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stretch to fill"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajustar para llenar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Étendre pour remplir"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拉伸以填充"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拉伸以填滿"
+          }
+        }
+      }
     },
     "StretchToFill" : {
       "extractionState" : "manual",
@@ -1938,7 +2114,39 @@
       }
     },
     "Wallpaper" : {
-
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wallpaper"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fondo de pantalla"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fond d'écran"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "壁纸"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "壁紙"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/Desktop Vdieo/Desktop Vdieo/UI/Sidebar/SidebarView.swift
+++ b/Desktop Vdieo/Desktop Vdieo/UI/Sidebar/SidebarView.swift
@@ -4,13 +4,14 @@ import AppKit
 
 struct SidebarView: View {
     @Binding var selection: SidebarSelection
+    @ObservedObject private var languageManager = LanguageManager.shared
     var body: some View {
         VStack(spacing: 8) {
             VStack {
                 Image(nsImage: NSApp.applicationIconImage)
                     .resizable()
                     .frame(width: 48, height: 48)
-                Text("Desktop Video")
+                Text(L("Desktop Video"))
                     .font(.footnote)
             }
             .frame(maxWidth: .infinity)
@@ -19,11 +20,11 @@ struct SidebarView: View {
             ForEach(SidebarSelection.allCases, id: \.self) { item in
                 switch item {
                 case .wallpaper:
-                    SidebarItem(icon: "sparkles", name: "Wallpaper", selection: item, current: $selection)
+                    SidebarItem(icon: "sparkles", name: LocalizedStringKey(L("Wallpaper")), selection: item, current: $selection)
                 case .playback:
-                    SidebarItem(icon: "bolt.circle", name: "Playback", selection: item, current: $selection)
+                    SidebarItem(icon: "bolt.circle", name: LocalizedStringKey(L("Playback")), selection: item, current: $selection)
                 case .general:
-                    SidebarItem(icon: "gearshape", name: "General", selection: item, current: $selection)
+                    SidebarItem(icon: "gearshape", name: LocalizedStringKey(L("General")), selection: item, current: $selection)
                 }
             }
             Spacer()


### PR DESCRIPTION
## Summary
- localize sidebar labels in the main controller
- complete translations for sidebar and media controls

## Testing
- `xcodebuild -project "Desktop Vdieo/Desktop Vdieo.xcodeproj" -scheme "Desktop Vdieo" -destination "platform=macOS" clean build` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68b671ad1b8c8330b5a63978eb145c39