### PR TITLE
fix: preserve temp video extension for playback

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,8 @@
 - Remove automatic cross-screen video sync; synchronization is now manual
 - 使用内存缓存视频数据以减少磁盘读取
 - Use in-memory video data caching to reduce disk reads
+- 修复内存播放视频缺少扩展名导致黑屏的问题
+- Fix black screen when temporary video files missed extensions
 
 ### Version 4.0 Preview 0909 hot-fix 4 (2025-09-11)
 

--- a/Desktop Video/Desktop Video/SharedWallpaperWindowManager.swift
+++ b/Desktop Video/Desktop Video/SharedWallpaperWindowManager.swift
@@ -930,15 +930,24 @@ class SharedWallpaperWindowManager {
     return false
   }
 
-  // Placeholder for missing AVDataAsset type
-  // If you have a custom AVDataAsset, import or define it. Otherwise, fallback to AVURLAsset or similar.
-  // For now, this is a stub to avoid build errors.
+  // MARK: - AVDataAsset
+  // 将内存中的视频数据写入带扩展名的临时文件以供播放
   class AVDataAsset: AVURLAsset, @unchecked Sendable {
-    convenience init(data: Data, contentType: UTType) {
-      // This is a stub. Replace with actual implementation if needed.
-      let tempURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+    private let tempURL: URL
+
+    init(data: Data, contentType: UTType) {
+      let ext = contentType.preferredFilenameExtension ?? "mov"
+      let tempURL = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent(UUID().uuidString)
+        .appendingPathExtension(ext)
       try? data.write(to: tempURL)
-      self.init(url: tempURL, options: nil)
+      dlog("create AVDataAsset temp file \(tempURL.lastPathComponent)")
+      self.tempURL = tempURL
+      super.init(url: tempURL, options: nil)
+    }
+
+    deinit {
+      try? FileManager.default.removeItem(at: tempURL)
     }
   }
 }

--- a/Desktop Video/Desktop Video/SpaceWallPaperManager.swift
+++ b/Desktop Video/Desktop Video/SpaceWallPaperManager.swift
@@ -127,12 +127,23 @@ final class SpaceWallpaperManager {
 }
 
 // MARK: - AVDataAsset Extension
-// Custom AVDataAsset class for creating video assets from data
+// Custom AVDataAsset class for creating video assets from in‑memory data
 class AVDataAsset: AVURLAsset, @unchecked Sendable {
-    convenience init(data: Data, contentType: UTType) {
-        // Create a temporary file from the data for video playback
-        let tempURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+    private let tempURL: URL
+
+    init(data: Data, contentType: UTType) {
+        // 使用临时文件承载内存中的视频数据，并保留正确的扩展名
+        let ext = contentType.preferredFilenameExtension ?? "mov"
+        let tempURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension(ext)
         try? data.write(to: tempURL)
-        self.init(url: tempURL, options: nil)
+        dlog("create AVDataAsset temp file \(tempURL.lastPathComponent)")
+        self.tempURL = tempURL
+        super.init(url: tempURL, options: nil)
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: tempURL)
     }
 }


### PR DESCRIPTION
## Summary
- ensure temporary video files retain correct extensions so videos play
- clean up temp files after use and log creation for easier debugging

## Testing
- `xcodebuild -project "Desktop Video/Desktop Video.xcodeproj" -scheme "Desktop Video" -destination "platform=macOS" clean build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c464c91ad483308e326bad1ac53978