### PR TITLE
Fix Settings scene build errors

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,15 @@
 
 **Desktop Video Wallpaper*- is a lightweight dynamic wallpaper app for macOS. It runs entirely offline — no data is uploaded or synced to the cloud, ensuring your privacy and local control.
 
+### Version 4.0 Preview 0909 hot-fix 11 (2025-09-15)
+
+- 修复 SwiftUI `Settings` 场景与应用内 `Settings` 单例的命名冲突，恢复偏好设置窗口
+- Resolve the naming clash between the SwiftUI `Settings` scene and the in-app `Settings` singleton so the preferences window opens correctly
+- 使用可选类型转换解析 `CGWindowBounds`，避免无效的强制类型转换警告
+- Switch `CGWindowBounds` parsing to optional casting to silence the invalid forced downcast warning
+- 将菜单栏形状计算中的中间矩形改为常量，清理未使用的变量警告
+- Promote intermediate menu bar geometry rectangles to constants to clear unused variable warnings
+
 ### Version 4.0 Preview 0909 hot-fix 10 (2025-09-15)
 
 - 通过 CGWindowScanner 精确识别第三方菜单栏遮罩，并自动匹配菜单栏高度

--- a/Desktop Video/Desktop Video/Desktop_VideoApp.swift
+++ b/Desktop Video/Desktop Video/Desktop_VideoApp.swift
@@ -56,7 +56,7 @@ struct desktop_videoApp: App {
             }
         }
 
-        Settings {
+        SwiftUI.Settings {
             PreferencesView()
         }
     }

--- a/Desktop Video/Desktop Video/UI/CGWindowScanner.swift
+++ b/Desktop Video/Desktop Video/UI/CGWindowScanner.swift
@@ -28,7 +28,7 @@ public enum CGWindowScanner {
                 let windowID = entry[kCGWindowNumber as String] as? UInt32,
                 let ownerName = entry[kCGWindowOwnerName as String] as? String,
                 let layer = entry[kCGWindowLayer as String] as? Int,
-                let bounds = rect(from: entry[kCGWindowBounds as String] as! [String : Any])
+                let bounds = rect(from: entry[kCGWindowBounds as String] as? [String : Any])
             else {
                 continue
             }

--- a/Desktop Video/Desktop Video/UI/MenuBarShapeBuilder.swift
+++ b/Desktop Video/Desktop Video/UI/MenuBarShapeBuilder.swift
@@ -30,13 +30,13 @@ enum MenuBarShapeBuilder {
         dlog(
             "MenuBarShapeBuilder.splitPath screen=\(screen.dv_localizedName) rect=\(NSStringFromRect(NSRectFromCGRect(rect)))"
         )
-        var workingRect = inset(rect: rect, with: info.notchInsets, applyInset: isInset)
+        let workingRect = inset(rect: rect, with: info.notchInsets, applyInset: isInset)
         let radius = workingRect.height / 2
         let minimumWidth = max(workingRect.height, 1)
 
         var leftWidth = max(info.applicationMenuRect.width, minimumWidth)
         leftWidth = min(leftWidth, workingRect.width)
-        var leftRect = CGRect(
+        let leftRect = CGRect(
             x: workingRect.minX,
             y: workingRect.minY,
             width: leftWidth,
@@ -48,7 +48,7 @@ enum MenuBarShapeBuilder {
         var rightOriginX = workingRect.maxX - info.statusItemsRect.width
         if rightWidth > info.statusItemsRect.width { rightOriginX = workingRect.maxX - rightWidth }
         rightOriginX = max(rightOriginX, workingRect.minX)
-        var rightRect = CGRect(
+        let rightRect = CGRect(
             x: rightOriginX,
             y: workingRect.minY,
             width: rightWidth,


### PR DESCRIPTION
## Summary
- disambiguate the SwiftUI Settings scene to avoid clashing with the app's Settings singleton
- relax the CGWindow bounds cast and promote menu bar rectangles to constants to clear Swift warnings
- document the fixes in the change log

## Testing
- xcodebuild   -project "Desktop Video/Desktop Video.xcodeproj"   -scheme "Desktop Video"   -destination "platform=macOS"   clean build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8685e17308330934a5c8108ae174a