### PR TITLE
fix: localize gb unit and refresh docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,21 +14,33 @@ This repository contains **Desktop Video Wallpaper**, a lightweight dynamic wall
 Desktop Video/
 ├── Desktop Video/
 │   ├── AppDelegate.swift
+│   ├── Assets.xcassets/
 │   ├── ContentView.swift
+│   ├── Core/
+│   │   └── WindowManager.swift
+│   ├── Desktop_Video.entitlements
 │   ├── Desktop_VideoApp.swift
 │   ├── KeyBindings.swift
 │   ├── LanguageManager.swift
+│   ├── Localizable.xcstrings
 │   ├── SharedWallpaperWindowManager.swift
 │   ├── SpaceWallPaperManager.swift
+│   ├── UI/
+│   │   ├── AppMainWindow.swift
+│   │   ├── Components/
+│   │   ├── Screens/
+│   │   └── Sidebar/
 │   ├── Utils.swift
-│   ├── WallpaperWindow.swift
-│   ├── Localizable.xcstrings
-│   ├── Theme/
 │   ├── ViewModels/
-│   └── UI/
-├── Desktop Video.xcodeproj
+│   │   ├── AppState.swift
+│   │   ├── AppViewModel.swift
+│   │   └── ScreenObserver.swift
+│   ├── WallpaperWindow.swift
+│   └── WallpaperWindowController.swift
+├── Desktop Video.xcodeproj/
 ├── Desktop VideoTests/
 ├── Desktop VideoUITests/
+├── DesktopVideoforMACTempleate.dmg
 ├── ChangeLog.md
 ├── README-EN.md
 ├── README.md

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,13 @@
 
 **Desktop Video Wallpaper*- is a lightweight dynamic wallpaper app for macOS. It runs entirely offline — no data is uploaded or synced to the cloud, ensuring your privacy and local control.
 
+### Version 4.0 Preview 0915 hot-fix 13 (2025-09-16)
+
+- 本地化设置中显示的 GB 单位并补齐多语言翻译
+- Localize the GB unit label and fill in all language variants
+- 添加了 macOS 26 Tahoe 支持
+- Added support for macOS 26 Tahoe
+
 ### Version 4.0 Preview 0915 hot-fix 12 (2025-09-16)
 
 - 修复应用启动时会弹出两个主窗口的问题，统一复用 SwiftUI 创建的主控制窗口

--- a/Desktop Video/Desktop Video/Desktop_VideoApp.swift
+++ b/Desktop Video/Desktop Video/Desktop_VideoApp.swift
@@ -213,7 +213,7 @@ struct PreferencesView: View {
                     Text(L("MaxVideoFileSizeGB"))
                     TextField("1.0", value: $maxVideoFileSizeInGB, formatter: NumberFormatter())
                         .frame(width: 50)
-                    Text("GB").font(.system(size: 14)) // 小字体
+                    Text(L("GB")).font(.system(size: 14)) // 小字体
                 }
                 .padding(.top, 10)
                 

--- a/Desktop Video/Desktop Video/Localizable.xcstrings
+++ b/Desktop Video/Desktop Video/Localizable.xcstrings
@@ -472,7 +472,39 @@
       }
     },
     "GB": {
-      "shouldTranslate": false
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GB"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GB"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Go"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GB"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GB"
+          }
+        }
+      }
     },
     "General": {
       "extractionState": "manual",


### PR DESCRIPTION
## Summary
- localize the GB unit label in the preferences view and provide translations for every supported language
- refresh AGENTS.md with the current project structure layout
- document the localization update and macOS 26 Tahoe support in the changelog

## Testing
- `xcodebuild -project "Desktop Video/Desktop Video.xcodeproj" -scheme "Desktop Video" -destination "platform=macOS" clean build` *(fails: xcodebuild not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8f0da7e808330af6d0be7e5ccb869